### PR TITLE
Add preinstall script to ensure app node modules installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "main.js",
   "scripts": {
     "dev": "electron --debug=5858 ./app",
+    "preinstall": "cd app && npm install",
     "gettext": "xgettext app/*.js -j --omit-header -o app/locale/messages.pot && xgettext app/html/*.html -L JavaScript -j --omit-header -o app/locale/messages.pot",
     "clean": "node clean.js",
     "build": "npm run clean && npm run build:osx && npm run build:win && npm run build:linux && npm run build:linux32",


### PR DESCRIPTION
Rejoining this project from an old, old fork from the bcalik days. Looks like a few packages have been added, but simply running `npm install; npm run dev` in the root from a fresh checkout doesn't actually go into the app directory and install NPM packages there. It's a minor thing but a frustration for anyone wanting to hack on this.