### PR TITLE
Add "blur images" setting

### DIFF
--- a/app/html/settings.html
+++ b/app/html/settings.html
@@ -59,6 +59,10 @@
         <input type="checkbox" id="darkMode" />
         <label for="darkMode"><script> document.write(_("Dark Mode")); </script></label>
       </p>
+      <p>
+        <input type="checkbox" id="blurImages" />
+        <label for="blurImages"><script> document.write(_("Blur images and emojis (visible on mouseover)")); </script></label>
+      </p>
       <div class="row">
         <div class="input-field col s8">
           <input id="thumb-size" type="number" class="validate"  min="50" max="150">

--- a/app/js/views/settings.js
+++ b/app/js/views/settings.js
@@ -41,6 +41,7 @@ var SettingsView = {
         }
 
         $("#darkMode").attr("checked", config.get("darkMode") == true);
+        $("#blurImages").attr("checked", config.get("blurImages") == true);
         $("#autoHideMenuBar").attr("checked", config.get("autoHideMenuBar") == true);
         $("#disablegpu").attr("checked", config.get("disablegpu") == true);
         $("#globalshortcut").attr("checked", config.get("globalshortcut") == true);
@@ -92,6 +93,7 @@ var SettingsView = {
         config.set("fontSize", $("#fontSize").val());
 
         config.set("darkMode", $("#darkMode").is(":checked"));
+        config.set("blurImages", $("#blurImages").is(":checked"));
         config.set("autoHideMenuBar", $("#autoHideMenuBar").is(":checked"));
         config.set("disablegpu", $("#disablegpu").is(":checked"));
         config.set("globalshortcut", $("#globalshortcut").is(":checked"));

--- a/app/main.js
+++ b/app/main.js
@@ -218,6 +218,9 @@
                  { background-color: #2E2C2B !important;, background-image: none !important; }\n \
                 .chat-title, .header-title, .chat-body div span { color: white; }';
 
+                var blurImages = "div.message-in img, div.message-out img { filter: contrast(25%) blur(8px) grayscale(75%); } \n \
+                div.message-in:hover img, div.message-out:hover img { filter: none; }";
+
                 if (config.currentSettings.hideAvatars) {
                     this.insertCSS(noAvatar);
                 }
@@ -226,6 +229,9 @@
                 }
                 if (config.currentSettings.darkMode){
                     this.insertCSS(darkMode);
+                }
+                if (config.currentSettings.blurImages) {
+                    this.insertCSS(blurImages);
                 }
 
                 if (config.currentSettings.thumbSize) {


### PR DESCRIPTION
Allows images and emojis to be blured and shown on mouseover.

Some users (like me) might prefer not to have emojis showing by default. For example it might not be desirable to have big emojis showing when using the app in a workplace. 
This could just as well have be done as a custom CSS but I though there might be other users who would like the feature.

Only tested on Linux.